### PR TITLE
[BUGFIX] Fix download URL to /start/install

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@ permalink: /
       {% endfor %}
       <div class="action-btns text-center">
         <a href="https://www.envoyproxy.io/docs/envoy/latest/start/start" class="btn-legacy btn-primary">Get Started</a>
-        <a href="https://www.envoyproxy.io/docs/envoy/latest/start/install" class="btn-legacy btn-secondary">Download</a>
+        <a href="https://github.com/envoyproxy/envoy/releases" class="btn-legacy btn-secondary">Download</a>
       </div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@ permalink: /
       {% endfor %}
       <div class="action-btns text-center">
         <a href="https://www.envoyproxy.io/docs/envoy/latest/start/start" class="btn-legacy btn-primary">Get Started</a>
-        <a href="https://www.envoyproxy.io/docs/envoy/latest/install/building" class="btn-legacy btn-secondary">Download</a>
+        <a href="https://www.envoyproxy.io/docs/envoy/latest/start/install" class="btn-legacy btn-secondary">Download</a>
       </div>
     </div>
 


### PR DESCRIPTION
Copied the URL that exists at the bottom of the page

Ref: https://github.com/envoyproxy/envoy-website/issues/296