### PR TITLE
site/build: Allow building without docs

### DIFF
--- a/build-website.sh
+++ b/build-website.sh
@@ -24,16 +24,12 @@ debug_jvm_fail () {
 
 inject_ci_bazelrc () {
     {
-
         PROC_COUNT="$(nproc)"
         PROCS=$((PROC_COUNT - 1))
         SPHINX_ARGS="-j 12 -v warn"
         echo "build:ci --action_env=SPHINX_RUNNER_ARGS=\"${SPHINX_ARGS}\""
         # echo "build:ci --local_ram_resources=20480"
-
     } > repo.bazelrc
-
-    cat repo.bazelrc
 }
 
 
@@ -43,15 +39,20 @@ if  [[ -e "$OUTPUT_DIR" ]]; then
 fi
 
 mkdir -p "${OUTPUT_DIR}"
-BAZEL_BUILD_ARGS=()
+
+if [[ -n "$BAZEL_BUILD_OPTIONS" ]]; then
+    read -ra BAZEL_BUILD_OPTIONS <<< $BAZEL_BUILD_OPTIONS
+else
+    BAZEL_BUILD_OPTIONS=()
+fi
 
 if [[ -n "$CI" ]]; then
-    BAZEL_BUILD_ARGS=(--config=ci)
+    BAZEL_BUILD_OPTIONS+=(--config=ci)
     inject_ci_bazelrc
 fi
 
 $BAZEL run \
-         "${BAZEL_BUILD_ARGS[@]}" \
+         "${BAZEL_BUILD_OPTIONS[@]}" \
          --@envoy//tools/tarball:target=//site \
          @envoy//tools/tarball:unpack \
          "$OUTPUT_DIR" || debug_jvm_fail

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ services:
     - ~/.cache/bazelisk:/$HOME/.cache/bazelisk
     working_dir: /src/workspace/envoy-website
     environment:
+      BAZEL_BUILD_OPTIONS: $BAZEL_BUILD_OPTIONS
       LOCAL_UID: ${UID:?"`UID` must be set, try `export UID`"}
       LOCAL_USER_NAME: $USERNAME
       LOCAL_USER_HOME: $HOME

--- a/site/BUILD
+++ b/site/BUILD
@@ -1,3 +1,4 @@
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@envoy_toolshed//website:macros.bzl", "static_website")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
@@ -36,20 +37,46 @@ label_flag(
     visibility = ["//visibility:public"],
 )
 
+bool_flag(
+    name = "no_docs_archive",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "disable_docs_archive",
+    flag_values = {":no_docs_archive": "True"},
+)
+
 label_flag(
     name = "docs_latest",
     build_setting_default = ":docs",
     visibility = ["//visibility:public"],
 )
 
+bool_flag(
+    name = "no_docs_latest",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "disable_docs_latest",
+    flag_values = {":no_docs_latest": "True"},
+)
+
 static_website(
     name = "site",
-    srcs = [":docs_archive"],
+    srcs = select({
+        ":disable_docs_archive": [],
+        "//conditions:default": [":docs_archive"],
+    }),
     compressor = "@envoy//tools/zstd",
     compressor_args = "-T0",
     content = "//site/content",
     data = "//site/data",
     extension = "tar.zst",
     theme = "//site/theme",
-    deps = [":docs_latest"],
+    deps = select({
+        ":disable_docs_latest": [],
+        "//conditions:default": [":docs_latest"],
+    }),
 )


### PR DESCRIPTION
with this change, you can build the site with no docs:

```console
export BAZEL_BUILD_OPTIONS="--//site:no_docs_archive=True --//site:no_docs_latest=True"
docker compose run build
```