### PR TITLE
nav: Remove blog link

### DIFF
--- a/site/data/nav.yaml
+++ b/site/data/nav.yaml
@@ -4,9 +4,6 @@
 - text: Docs
   url: /docs
 
-- text: Blog
-  url: https://blog.envoyproxy.io
-
 - text: Community
   url: /community
 


### PR DESCRIPTION
blog.envoyproxy.io is not maintained and the link is broken.